### PR TITLE
Change default queue name to cun_default, document health check plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ The method expects a block that will receive an exception, and run in the scope 
 
 ## Retry mechanism
 
-Cuniculus declares a `default` queue, together with some `default_{n}` queues used for job retries.
-When a job raises an exception, it is placed into the `default_1` queue for the first retry. It stays there for some pre-defined time, and then gets moved back into the `default` queue for execution.
+Cuniculus declares a `cun_default` queue, together with some `cun_default_{n}` queues used for job retries.
+When a job raises an exception, it is placed into the `cun_default_1` queue for the first retry. It stays there for some pre-defined time, and then gets moved back into the `cun_default` queue for execution.
 
-If it fails again, it gets moved to `default_2`, where it stays for a longer period until it's moved back directly into the `default` queue again.
+If it fails again, it gets moved to `cun_default_2`, where it stays for a longer period until it's moved back directly into the `cun_default` queue again.
 
-This goes on until there are no more retry attempts, in which case the job gets moved into the `cun_dead` queue. It can be then only be moved back into the `default` queue manually; otherwise it is discarded after some time, defined as the `dead_queue_ttl`, in milliseconds (by default, 180 days).
+This goes on until there are no more retry attempts, in which case the job gets moved into the `cun_dead` queue. It can be then only be moved back into the `cun_default` queue manually; otherwise it is discarded after some time, defined as the `dead_queue_ttl`, in milliseconds (by default, 180 days).
 
 Note that if a job cannot even be parsed, it is moved straight to the dead queue, as there's no point in retrying.
 

--- a/examples/init_cuniculus.rb
+++ b/examples/init_cuniculus.rb
@@ -21,4 +21,4 @@ Cuniculus.error_handler do |e|
   puts "Oh nein! #{e}"
 end
 
-Cuniculus.plugin(:health_check)
+Cuniculus.plugin(:health_check, { "bind_to" => "0.0.0.0", "port" => 3000 })

--- a/lib/cuniculus/config.rb
+++ b/lib/cuniculus/config.rb
@@ -14,7 +14,7 @@ module Cuniculus
 
     def initialize
       @opts = {}
-      @queues = { "default" => QueueConfig.new({ "name" => "default" }) }
+      @queues = { "cun_default" => QueueConfig.new({ "name" => "cun_default" }) }
       @rabbitmq_opts = {
         host: "127.0.0.1",
         port: 5672,
@@ -36,7 +36,7 @@ module Cuniculus
     end
 
     def default_queue=(bool)
-      @queues.delete("default") unless bool
+      @queues.delete("cun_default") unless bool
     end
 
     private

--- a/lib/cuniculus/plugins/health_check.rb
+++ b/lib/cuniculus/plugins/health_check.rb
@@ -5,15 +5,56 @@ require "thread"
 
 module Cuniculus
   module Plugins
+    # The HealthCheck plugin starts a TCP server together with consumers for health probing.
+    # It currently does not perform any additional checks returns '200 OK' regardless of whether
+    # - the node can connect to RabbitMQ;
+    # - consumers are stuck.
+    #
+    # The healthcheck stays up as long as the supervisor module is also running.
+    #
+    # Enable the plugin with:
+    # ```ruby
+    # Cuniculus.plugin(:health_check)
+    # ```
+    #
+    # Options may be passed as well (use `String` keys):
+    # ```ruby
+    # opts = {
+    #   "bind_to" => "127.0.0.1", # Default: "0.0.0.0"
+    #   "port" => 8080            # Default: 3000
+    # }
+    # Cuniculus.plugin(:health_check, opts)
+    # ```
+    # This starts the server bound to 127.0.0.1 and port 8080.
+    #
+    # Note that the request path is not considered. The server responds with 200 to any path.
     module HealthCheck
       HEALTH_CHECK_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
 
-      def self.configure(opts, bind_to = "0.0.0.0", port = 3000, &block)
-        opts["__health_check_opts"] = {
-          "bind_to" => bind_to,
-          "port" => port
-        }
-        opts["__health_check_opts"]["block"] = block if block
+      DEFAULTS = {
+        "bind_to" => "0.0.0.0",
+        "port" => 3000,
+        "server" => "webrick",
+        "block" => nil
+      }.freeze
+
+      OPTS_KEY = "__health_check_opts" # Key in the global plugin options where `:health_check` plugin options are stored.
+
+      # Configure `health_check` plugin
+      #
+      # @param plugins_cfg [Hash] Global plugin config hash, passed by Cuniculus. This should not be used by plugin users.
+      # @param opts [Hash] Plugin specific options.
+      # @option opts [String] "bind_to" IP address to bind to (default: "0.0.0.0")
+      # @option opts [Numeric] "port" Port number to bind to (default: 3000)
+      def self.configure(plugins_cfg, opts = {}, &block)
+        invalid_opts = opts.keys - DEFAULTS.keys
+        raise Cuniculus::Error, "Invalid option keys for :health_check plugin: #{invalid_opts}" unless invalid_opts.empty?
+
+        plugins_cfg[OPTS_KEY] = h = opts.slice("bind_to", "port", "server")
+        h["block"] = block if block
+        DEFAULTS.each do |k, v|
+          h[k] = v if v && !h.key?(k)
+        end
       end
 
       module SupervisorMethods
@@ -32,7 +73,7 @@ module Cuniculus
         private
 
         def start_health_check_server(pipe_reader)
-          opts = config.opts["__health_check_opts"]
+          opts = config.opts[OPTS_KEY]
           server = ::TCPServer.new(opts["bind_to"], opts["port"])
 
           # If port was assigned by OS (when 'port' option was given as 0),

--- a/lib/cuniculus/queue_config.rb
+++ b/lib/cuniculus/queue_config.rb
@@ -13,7 +13,7 @@ module Cuniculus
     attr_reader :max_retry, :name, :thread_pool_size
 
     def initialize(opts = OPTS)
-      @name = read_opt(opts, "name") || "default"
+      @name = read_opt(opts, "name") || "cun_default"
       @max_retry = read_opt(opts, "max_retry") || DEFAULT_MAX_RETRY
       @thread_pool_size = read_opt(opts, "thread_pool_size")
     end

--- a/lib/cuniculus/worker.rb
+++ b/lib/cuniculus/worker.rb
@@ -15,7 +15,7 @@ module Cuniculus
       end
 
       def publish(item)
-        routing_key = "default"
+        routing_key = "cun_default"
         payload = normalize_item(item)
         Cuniculus::RMQPool.with_exchange do |x|
           x.publish(payload, { routing_key: routing_key, persistent: true })

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -35,17 +35,17 @@ RSpec.describe Cuniculus::Config do
 
     it "creates the default queue" do
       subject.declare!
-      expect(RMQControl.get_queues).to include("default")
+      expect(RMQControl.get_queues).to include("cun_default")
     end
 
     context "when default_queue is set to false" do
       before do
-        RMQControl.delete_queues(["default"])
+        RMQControl.delete_queues(["cun_default"])
         config.default_queue = false
       end
       it "creates the default queue" do
         subject.declare!
-        expect(RMQControl.get_queues).not_to include("default")
+        expect(RMQControl.get_queues).not_to include("cun_default")
       end
     end
 

--- a/spec/plugins/health_check_spec.rb
+++ b/spec/plugins/health_check_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Cuniculus::Plugins::HealthCheck do
       include Cuniculus::Plugins::HealthCheck::SupervisorMethods
     end
 
-    described_class.configure(config.opts, "0.0.0.0", 3000)
+    opts = { "bind_to" => "0.0.0.0", "port" => 0 }
+    described_class.configure(config.opts, opts)
     k.new(config)
   end
 

--- a/spec/queue_config_spec.rb
+++ b/spec/queue_config_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe Cuniculus::QueueConfig do
 
     # Make sure to clear both the queue in RMQ and the cached queue in @channel
     @channel.queues.each_value(&:delete)
-    RMQControl.delete_queues(["default"])
+    RMQControl.delete_queues(["cun_default"])
   end
 
   after(:each) do
     @channel.queues.each_value(&:delete)
-    RMQControl.delete_queues(["default"])
+    RMQControl.delete_queues(["cun_default"])
   end
 
   describe "declare!" do
@@ -39,14 +39,14 @@ RSpec.describe Cuniculus::QueueConfig do
 
       it "declares base queue and associated retry queues" do
         subject.declare!(@channel)
-        expect(@channel.queues.keys).to eq(%w[default default_1 default_2])
+        expect(@channel.queues.keys).to eq(%w[cun_default cun_default_1 cun_default_2])
       end
     end
 
     context "when a queue already exists with conflicting configs" do
       before do
         channel = @conn.create_channel # separate channel to avoid the cached queue in @channel
-        channel.queue("default", durable: false)
+        channel.queue("cun_default", durable: false)
       end
       it "raises a RMQQueueConfigurationConflict error" do
         expect { subject.declare!(@channel) }.to raise_error(Cuniculus::RMQQueueConfigurationConflict)


### PR DESCRIPTION
It's one PR, but doing two separate things:
- Change queue name from `default` to `cun_default`, to prevent name collision;
- Change how options are passed to the `:health_check` plugin (start using an `opts` hash), and document it.