### PR TITLE
Worker-specific options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: docs doc_server
+
+docs: yard_lib_docs/.dirtimestamp
+
+yard_lib_docs/.dirtimestamp: README.md lib/*.rb lib/cuniculus/*.rb
+	@yard doc
+	@touch yard_lib_docs/.dirtimestamp
+
+doc_server:
+	@yard server -r

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ require 'cuniculus/worker'
 class MyWorker
   include Cuniculus::Worker
 
+  # the queue name is not explicitly given, so "cun_default" is used.
+
   def perform(arg1, arg2)
     puts "Processing:"
     puts "arg1: #{arg1.inspect}"
@@ -82,6 +84,8 @@ There is also a more complete example in the Cuniculus repository itself. To run
   bin/cuniculus -I examples/ -r example/init_cuniculus.rb
   ```
 
+The `-I examples` option adds the `examples/` directory into the load path, and `-r example/init_cuniculus.rb` requires `init_cuniculus.rb` prior to starting the consumer. The latter is where configurations such as described in the section section should be.
+
 ## Configuration
 
 Configuration is done through code, using `Cuniculus.configure`. 
@@ -105,6 +109,20 @@ Cuniculus.configure do |cfg|
   cfg.rabbitmq_opts = rabbitmq_conn
   cfg.pub_thr_pool_size = 5         # Only affects job producers
   cfg.dead_queue_ttl = 1000 * 60 * 60 * 24 * 30 # keep failed jobs for 30 days
+  cfg.add_queue({ name: "critical", durable: true, max_retry: 10, prefetch_count: 1})
+end
+```
+
+To configure the queue used by a worker, used `cuniculus_options`:
+
+```ruby
+class MyWorker
+  include Cuniculus::Worker
+
+  cuniculus_options queue: "critical"
+  def perform
+    # code
+  end
 end
 ```
 
@@ -122,12 +140,15 @@ The method expects a block that will receive an exception, and run in the scope 
 
 ## Retry mechanism
 
-Cuniculus declares a `cun_default` queue, together with some `cun_default_{n}` queues used for job retries.
+Retries are enabled by default (with 8 retries) with an exponential backoff, meaning the time between retries increases the more failures happen. The formula for calculating the times between retries can be found in {Cuniculus::QueueConfig}, namely in the `x-message-ttl` line. As an example, the time between the 7th and 8th retries is roughly 29 days.
+
+Given a declared queue in the configuration, Cuniculus starts on RabbitMQ the corresponding base queue, in addition to its retry queues. As an example, let's consider the default queue `cun_default`: Cuniculus declares a `cun_default` queue, together with some `cun_default_{n}` queues used for job retries.
+
 When a job raises an exception, it is placed into the `cun_default_1` queue for the first retry. It stays there for some pre-defined time, and then gets moved back into the `cun_default` queue for execution.
 
 If it fails again, it gets moved to `cun_default_2`, where it stays for a longer period until it's moved back directly into the `cun_default` queue again.
 
-This goes on until there are no more retry attempts, in which case the job gets moved into the `cun_dead` queue. It can be then only be moved back into the `cun_default` queue manually; otherwise it is discarded after some time, defined as the `dead_queue_ttl`, in milliseconds (by default, 180 days).
+This goes on until there are no more retry attempts, in which case the job gets moved into the `cun_dead` queue. It can be then only be moved back into the `cun_default` queue manually; otherwise it is discarded after some time, defined as the {Cuniculus::Config.dead_queue_ttl}, in milliseconds (by default, 180 days).
 
 Note that if a job cannot even be parsed, it is moved straight to the dead queue, as there's no point in retrying.
 

--- a/examples/init_cuniculus.rb
+++ b/examples/init_cuniculus.rb
@@ -15,6 +15,7 @@ rabbitmq_conn = {
 
 Cuniculus.configure do |cfg|
   cfg.rabbitmq_opts = rabbitmq_conn
+  cfg.add_queue({ "name" => "my_queue", "durable" => false })
 end
 
 Cuniculus.error_handler do |e|

--- a/examples/my_worker.rb
+++ b/examples/my_worker.rb
@@ -4,6 +4,7 @@ require "cuniculus/worker"
 
 class MyWorker
   include Cuniculus::Worker
+  cuniculus_options queue: "my_queue"
 
   def perform(arg1, arg2)
     puts "Processing:"

--- a/examples/produce.rb
+++ b/examples/produce.rb
@@ -15,6 +15,7 @@ rabbitmq_conn = {
 
 Cuniculus.configure do |cfg|
   cfg.rabbitmq_opts = rabbitmq_conn
+  cfg.add_queue({ "name" => "my_queue", "durable" => false })
   cfg.pub_thr_pool_size = 5
 end
 

--- a/lib/cuniculus.rb
+++ b/lib/cuniculus.rb
@@ -14,12 +14,14 @@ require "cuniculus/supervisor"
 module Cuniculus
 
   # Configure Cuniculus.
+  # Check {Cuniculus::Config} for the available options.
   #
   # @yield [Cuniculus::Config]
   #
   # @example Change RabbitMQ connection details.
   #   Cuniculus.configure do |cfg|
   #     cfg.rabbitmq_opts = { host: 'rmq.mycompany.com', user: 'guest', pass: 'guest' }
+  #     cfg.add_queue({ name: "new_queue", max_retry: 4 })
   #   end
   def self.configure
     cfg = Cuniculus::Config.new

--- a/lib/cuniculus/core.rb
+++ b/lib/cuniculus/core.rb
@@ -23,7 +23,7 @@ module Cuniculus
     # the message and backtrace of `exception`.
     #
     # @param exception [Exception] The exception being wrapped
-    # @param [Cuniculus::Error] The subclass of `Cuniculus::Error`
+    # @param klass [Cuniculus::Error] The subclass of `Cuniculus::Error`
     #
     # @return [Cuniculus::Error] An instance of the input `Cuniculus::Error`
     def convert_exception_class(exception, klass)

--- a/lib/cuniculus/exceptions.rb
+++ b/lib/cuniculus/exceptions.rb
@@ -5,12 +5,14 @@ module Cuniculus
   #
   # * `Cuniculus::Error`: Default exception raised by Cuniculus.
   #   All exceptions classes defined by Cuniculus descend from this class.
-  # * `Cuniculus::RMQConnectionError`: Raised when unable to connect to RabbitMQ.
-  # * `Cuniculus::RMQQueueConfigurationConflict`: Raised when the queue configuration
+  # * `Cuniculus::BadlyFormattedPayload`: A Cuniculus consumer received an
+  #   improperly formatted job message.
+  # * `Cuniculus::ConfigError`: Incorrect configuration passed to Cuniculus.
+  # * `Cuniculus::RMQConnectionError`: Unable to connect to RabbitMQ.
+  # * `Cuniculus::RMQQueueConfigurationConflict`: The queue configuration
   #   given to Cuniculus conflicts with the current configuration of the same
   #   existing queue in RabbitMQ.
-  # * `Cuniculus::BadlyFormattedPayload`: Raised when Cuniculus consumer receives an
-  #   improperly formatted job message.
+  # * `Cuniculus::WorkerOptionsError`: Invalid options passed to cuniculus_options.
 
   class Error < ::StandardError
     # If the Cuniculus exception wraps an underlying exception, the latter
@@ -25,6 +27,14 @@ module Cuniculus
     end
   end
 
+  # Dev note:
+  # As explained [here](https://github.com/jeremyevans/sequel/commit/24681efad0fec48195e43801c224bf18cdc8be13#diff-64cd7b67eccdc6dfa69c23b3b19f34e318f9e6827c5dee5f6e845b2993ab035c), empty classes created
+  # with `Class.new` require about 200 bytes less memory than ones created as `class MyClass; end`.
+  # The call to `name` is used so that the names of such classes are cached before runtime.
+  (
+    BadlyFormattedPayload = Class.new(Error)
+  ).name
+
   (
     ConfigError = Class.new(Error)
   ).name
@@ -37,7 +47,8 @@ module Cuniculus
     RMQQueueConfigurationConflict = Class.new(Error)
   ).name
 
+
   (
-    BadlyFormattedPayload = Class.new(Error)
+    WorkerOptionsError = Class.new(Error)
   ).name
 end

--- a/lib/cuniculus/supervisor.rb
+++ b/lib/cuniculus/supervisor.rb
@@ -37,9 +37,8 @@ module Cuniculus
 
     def create_consumers(conn, queues)
       consumers = []
-      consumer_pool_size = 5
       queues.each do |_name, q_cfg|
-        ch = conn.create_channel(nil, consumer_pool_size)
+        ch = conn.create_channel(nil, q_cfg.thread_pool_size)
         ch.prefetch(q_cfg.prefetch_count) if q_cfg.prefetch_count
         consumers << Cuniculus::Consumer.new(q_cfg, ch)
       end

--- a/lib/cuniculus/worker.rb
+++ b/lib/cuniculus/worker.rb
@@ -7,15 +7,67 @@ module Cuniculus
   module Worker
     def self.included(base)
       base.extend(ClassMethods)
+
+      # Dev note:
+      # The point here is to allow options set via cuniculus_options to be
+      # inherited by subclasses.
+      # When reading the options, a subclass will call the singleton method cun_opts.
+      # If the subclass doesn't redefine this method via a call to cuniculus_options,
+      # it will still use the definition from its parent class.
+      base.define_singleton_method("cun_opts=") do |opts|
+        singleton_class.class_eval do
+          define_method("cun_opts") { opts }
+        end
+      end
     end
 
     module ClassMethods
+      DEFAULT_OPTS = { "queue" => "cun_default" }.freeze
+      VALID_OPT_KEYS = %w[queue].freeze
+
+      # Read-only cuniculus option values
+      #
+      # @return opts [Hash] hash with current values
+      def cun_opts
+        DEFAULT_OPTS
+      end
+
+      # Worker-specific options for running cuniculus.
+      #
+      # Note that options set on a worker class are inherited by its subclasses.
+      #
+      # @param opts [Hash]
+      # @option opts [String] "queue" ("cun_default") Name of the underlying RabbitMQ queue.
+      #
+      # @example Change the queue name of a worker
+      #   class MyWorker
+      #     include Cuniculus::Worker
+      #
+      #     cuniculus_options queue: "critical"
+      #
+      #     def perform
+      #       # run the task
+      #     end
+      #   end
+      def cuniculus_options(opts)
+        opts = validate_opts!(opts)
+        self.cun_opts = opts
+      end
+
+      def validate_opts!(opts)
+        raise WorkerOptionsError, "Argument passed to 'cuniculus_options' should be a Hash" unless opts.is_a?(Hash)
+        opts = opts.transform_keys(&:to_s)
+        invalid_keys = opts.keys - VALID_OPT_KEYS
+        raise WorkerOptionsError, "Invalid keys passed to 'cuniculus_options': #{invalid_keys.inspect}" unless invalid_keys.empty?
+        opts
+      end
+
       def perform_async(*args)
         publish({ "class" => self, "args" => args })
       end
 
       def publish(item)
-        routing_key = "cun_default"
+        routing_key = cun_opts["queue"]
         payload = normalize_item(item)
         Cuniculus::RMQPool.with_exchange do |x|
           x.publish(payload, { routing_key: routing_key, persistent: true })

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Cuniculus::Config do
   before do
     config.rabbitmq_opts = @rmq_opts
     RMQControl.delete_exchanges
-    RMQControl.delete_queues(["cun_dead"])
+    RMQControl.delete_queues(%w[q1 q1_1 cun_dead])
   end
 
   # Make sure to recreate the exchanges so other tests can run
@@ -52,6 +52,34 @@ RSpec.describe Cuniculus::Config do
     it "declares dead queue and binds to DLX exchange" do
       subject.declare!
       expect(RMQControl.get_bindings(Cuniculus::CUNICULUS_DLX_EXCHANGE)).to include("cun_dead")
+    end
+  end
+
+  describe "add_queue" do
+    context "when passed options don't contain a 'name' key" do
+      let(:queue_opts) { { random_key: " " } }
+      it { expect { subject.add_queue(queue_opts) }.to raise_exception(Cuniculus::ConfigError) }
+    end
+
+    context "when passed options don't contain a valid 'name' key" do
+      let(:queue_opts) { { name: " " } }
+      it { expect { subject.add_queue(queue_opts) }.to raise_exception(Cuniculus::ConfigError) }
+    end
+
+    context "when options are valid" do
+      let(:queue_opts) do
+        {
+          name: "q1", durable: false, max_retry: 1, prefetch_count: 50
+        }
+      end
+      it "stores QueueConfig object with correct parameters" do
+        subject.add_queue(queue_opts)
+        q = subject.queues["q1"]
+        expect(q.name).to eq("q1")
+        expect(q.durable).to eq(false)
+        expect(q.max_retry).to eq(1)
+        expect(q.prefetch_count).to eq(50)
+      end
     end
   end
 end

--- a/spec/queue_config_spec.rb
+++ b/spec/queue_config_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Cuniculus::QueueConfig do
 
     before { stub_const("Cuniculus::QueueConfig::DEFAULT_MAX_RETRY", 2) }
     context "with default opts" do
-
       it "declares base queue and associated retry queues" do
         subject.declare!(@channel)
         expect(@channel.queues.keys).to eq(%w[cun_default cun_default_1 cun_default_2])
@@ -49,7 +48,18 @@ RSpec.describe Cuniculus::QueueConfig do
         channel.queue("cun_default", durable: false)
       end
       it "raises a RMQQueueConfigurationConflict error" do
-        expect { subject.declare!(@channel) }.to raise_error(Cuniculus::RMQQueueConfigurationConflict)
+        expect { subject.declare!(@channel) }.to raise_exception(Cuniculus::RMQQueueConfigurationConflict)
+      end
+    end
+
+    context "with non-default options" do
+      let(:opts) do
+        { name: "test_queue", durable: false, max_retry: 1, prefetch_count: 99, thread_pool_size: 7 }
+      end
+      it "declares base queue and associated retry queues" do
+        subject.declare!(@channel)
+        expect(@channel.queues.keys).to eq(%w[test_queue test_queue_1])
+        expect(@channel.queues.values.map(&:durable?)).not_to include(true)
       end
     end
   end

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "rmq_control"
+require "cuniculus/supervisor"
+require "cuniculus/config"
+require "cuniculus/queue_config"
+
+RSpec.describe Cuniculus::Supervisor do
+  let(:supervisor) { described_class.new(config) }
+
+  let(:conn_opts) do
+    rmq_host = ENV["RMQ_HOST"] || "rabbitmq"
+    { host: rmq_host, port: 5672, user: "guest", pass: "guest", vhost: "/" }
+  end
+
+  let(:config) do
+    Cuniculus::Config.new.tap do |cfg|
+      cfg.rabbitmq_opts = conn_opts
+    end
+  end
+
+  before(:all) do
+    RMQControl.wait_live(10)
+  end
+
+  describe "create_consumers" do
+    subject { supervisor.create_consumers(connection, queues) }
+    let(:connection) { supervisor.connect(conn_opts) }
+    let(:queues) do
+      {
+        "q1" => Cuniculus::QueueConfig.new({ "name" => "q1", "max_retry" => 0, "durable" => false, "prefetch_count" => 66 }),
+        "q2" => Cuniculus::QueueConfig.new({ "name" => "q2", "max_retry" => 0, "durable" => false, "prefetch_count" => 77 })
+      }
+    end
+
+    it "creates channels with configured prefetch counts" do
+      channels = subject.map(&:channel)
+      q1 = subject.find { |c| c.queue_config.name == "q1" }
+      q2 = subject.find { |c| c.queue_config.name == "q2" }
+      expect(q1.channel.prefetch_count).to eq(66)
+      expect(q2.channel.prefetch_count).to eq(77)
+    end
+  end
+end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "cuniculus/worker"
+
+RSpec.describe Cuniculus::Worker do
+  let(:worker) do
+    Class.new do
+      include Cuniculus::Worker
+    end
+  end
+  describe "cuniculus_options" do
+    subject { worker.cuniculus_options(opts) }
+
+    context "when cuniculus_options is not called" do
+      it "uses default values" do
+        expect(worker.cun_opts).to include(
+          "queue" => "cun_default"
+        )
+      end
+    end
+
+    context "when the wrong argument type is passed" do
+      let(:opts) { "a string" }
+      it { expect { subject }.to raise_exception(Cuniculus::WorkerOptionsError) }
+    end
+
+    context "when invalid keys are passed" do
+      let(:opts) do
+        { "invalid_key" => 123, "another_invalid_key" => 3, "queue" => "q" }
+      end
+      it { expect { subject }.to raise_exception(Cuniculus::WorkerOptionsError) }
+    end
+
+    context "when there is a subclass of the original worker class" do
+      let(:child_worker) do
+        Class.new(worker)
+      end
+      before do
+        worker.cuniculus_options({ "queue" => "q1" })
+      end
+
+      it "inherits the options from the parent worker" do
+        expect(child_worker.cun_opts["queue"]).to eq("q1")
+      end
+
+      context "when child worker overrides the options" do
+        before { child_worker.cuniculus_options({ "queue" => "q2" }) }
+        it { expect(child_worker.cun_opts["queue"]).to eq("q2") }
+
+        it "does not change the parent worker options" do
+          expect(worker.cun_opts["queue"]).to eq("q1")
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Allows the queue to be specified per worker.

Also, configurations of additional queues (added via `add_queue`) are respected, and additional options such as `durable` and `prefetch_count` are accepted.