### PR TITLE
Config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Cuniculus.configure do |cfg|
 end
 ```
 
-To configure the queue used by a worker, used `cuniculus_options`:
+To configure the queue used by a worker, use `cuniculus_options`:
 
 ```ruby
 class MyWorker

--- a/lib/cuniculus/config.rb
+++ b/lib/cuniculus/config.rb
@@ -13,18 +13,19 @@ module Cuniculus
       log_level: ::Logger::ERROR
     }.freeze
 
-    attr_accessor(
+    attr_reader(
       :dead_queue_ttl,
       :exchange_name,
+      :opts,
       :pub_pool_size,
       :pub_reconnect_attempts,
       :pub_reconnect_delay,
       :pub_reconnect_delay_max,
       :pub_shutdown_grace_period,
-      :rabbitmq_opts
+      :queues
     )
 
-    attr_reader :queues, :opts
+    attr_accessor :rabbitmq_opts
 
     def initialize
       @opts = {}
@@ -47,6 +48,41 @@ module Cuniculus
       @pub_pool_size = 5
       ## ---- End of default values
     end
+
+      def dead_queue_ttl=(ttl)
+        raise Cuniculus::ConfigError, "dead_queue_ttl should be a positive integer, given #{ttl.inspect}" if ttl.to_i <= 0
+        @dead_queue_ttl = ttl
+      end
+
+      def exchange_name=(xname)
+        raise Cuniculus::ConfigError, "exchange_name should not be blank" if xname.to_s.empty?
+        @exchange_name = xname
+      end
+
+      def pub_pool_size=(pool_size)
+        raise Cuniculus::ConfigError, "pub_pool_size should be a positive integer, given #{pool_size.inspect}" if pool_size.to_i <= 0
+        @pub_pool_size = pool_size
+      end
+
+      def pub_reconnect_attempts=(attempts)
+        raise Cuniculus::ConfigError, "pub_reconnect_attempts should be either :infinite or a non-negative integer, was given #{attempts.inspect}" if attempts != :infinite && attempts.to_i < 0
+        @pub_reconnect_attempts = attempts
+      end
+
+      def pub_reconnect_delay=(delay)
+        raise Cuniculus::ConfigError, "pub_reconnect_delay should be a non-negative integer, was given #{delay.inspect}" if delay.to_i < 0
+        @pub_reconnect_delay = delay
+      end
+
+      def pub_reconnect_delay_max=(delay)
+        raise Cuniculus::ConfigError, "pub_reconnect_delay_max should be a non-negative integer, was given #{delay.inspect}" if delay.to_i < 0
+        @pub_reconnect_delay_max = delay
+      end
+
+      def pub_shutdown_grace_period=(period)
+        raise Cuniculus::ConfigError, "pub_shutdown_grace_period should be a non-negative integer, was given #{period.inspect}" if period.to_i < 0
+        @pub_shutdown_grace_period = period
+      end
 
     # Configure an additional queue
     #

--- a/lib/cuniculus/config.rb
+++ b/lib/cuniculus/config.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "logger"
 require "cuniculus/core"
 require "cuniculus/exceptions"
 require "cuniculus/queue_config"
@@ -9,7 +10,7 @@ module Cuniculus
     ENFORCED_CONN_OPTS = {
       threaded: false, # No need for a reader thread, since this connection is only used for declaring exchanges and queues.
       automatically_recover: false,
-      log_level: Logger::ERROR
+      log_level: ::Logger::ERROR
     }.freeze
 
     attr_accessor(

--- a/lib/cuniculus/dispatcher.rb
+++ b/lib/cuniculus/dispatcher.rb
@@ -15,7 +15,7 @@ module Cuniculus
     ENFORCED_CONN_OPTS = {
       threaded: false, # No need for a reader thread, since this connection is only used for publishing
       automatically_recover: false,
-      logger: Logger.new(IO::NULL)
+      logger: ::Logger.new(IO::NULL)
     }.freeze
     RECOVERABLE_ERRORS = [AMQ::Protocol::Error, ::Bunny::Exception, Errno::ECONNRESET].freeze
 

--- a/spec/dispatcher_spec.rb
+++ b/spec/dispatcher_spec.rb
@@ -1,6 +1,7 @@
 
 # frozen_string_literal: true
 
+require "logger"
 require "stringio"
 require_relative "spec_helper"
 require_relative "rmq_control"
@@ -9,11 +10,6 @@ require "cuniculus/logger"
 require "cuniculus/dispatcher"
 
 RSpec.describe Cuniculus::Dispatcher do
-  let(:channel) { instance_double("Bunny::Channel", ack: nil, nack: nil) }
-  let(:queue) { instance_double("Bunny::Queue", subscribe: nil) }
-  let(:queue_config) { instance_double("Cuniculus::QueueConfig", declare!: nil) }
-  let(:exchange) { instance_double("Bunny::Exchange", publish: nil) }
-
   before(:all) do
     rmq_host = ENV["RMQ_HOST"] || "rabbitmq"
     @rmq_opts = { host: rmq_host, port: 5672, user: "guest", pass: "guest", vhost: "/" }

--- a/spec/pub_worker_spec.rb
+++ b/spec/pub_worker_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Cuniculus::PubWorker do
 
   subject { described_class.new(config, job_queue, dispatcher_chan) }
 
+  # Make sure background thread is terminates before continuing with other tests
+  after do
+    job_queue << :shutdown
+    t0 = Cuniculus.mark_time
+    while subject.alive? && (Cuniculus.mark_time - t0 < 5)
+      job_queue << :shutdown
+      sleep 0.2
+    end
+  end
+
   let(:connection) do
     ::Bunny.new(config.rabbitmq_opts)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 require "rspec"
 require "pry"
 
+Thread.abort_on_exception = true
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Give clear error messages as early as possible when configuring Cuniculus.

This PR also makes some specs more stable.