### PR TITLE
Use extend to include worker methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,36 +3,6 @@
 
 Ruby job queue backed by RabbitMQ. The word _cuniculus_ comes from the scientific name of the European rabbit (Oryctolagus cuniculus).
 
-## Benchmarks
-
-The following measurements were performed with the `bin/run_benchmarks` utility, with different command parameters. Run it with `-h` to see its usage.
-
-To simulate network latency, [Toxiproxy](https://github.com/Shopify/toxiproxy) was used. It needs to be started with `toxiproxy-server` before running the benchmarks.
-
-Network latency (_ms_) | Prefetch count       | Throughput (_jobs/s_) | Average latency (_ms_)
-----------------------:|---------------------:|----------------------:|----------------------:
-1                      | 65535 (max. allowed) | 10225                 | 2
-10                     | 65535 (max. allowed) | 9990                  | 13
-1                      |                   50 | 8051                  | 2
-10                     |                   50 | 2500                  | 13
-100                    |                   50 | 481                   | 103
-1                      |                   25 | 7824                  | 2
-10                     |                   25 | 1824                  | 13
-50                     |                   25 | 469                   | 53
-1                      |         10 (default) | 5266                  | 2
-10                     |         10 (default) | 807                   | 13
-1                      |                    1 | 481                   | 2
-10                     |                    1 | 81                    | 13
-
-Additional benchmark parameters:
-- throughput was measured by consuming 100k jobs;
-- job latency was averaged over 200 samples;
-- Ruby 2.7.2 was used.
-
-Several remarks can be made:
-- Higher prefetch counts lead to higher throughput, but there are downsides of having it too high; see [this reference](https://www.cloudamqp.com/blog/2017-12-29-part1-rabbitmq-best-practice.html#prefetch) on how to properly tune it.
-- Network latency has a severe impact on the throughput, and the effect is larger the smaller the prefetch count is.
-
 ## Getting started
 
 ```sh
@@ -47,7 +17,7 @@ Create a worker class:
 require 'cuniculus/worker'
 
 class MyWorker
-  include Cuniculus::Worker
+  extend Cuniculus::Worker
 
   # the queue name is not explicitly given, so "cun_default" is used.
 
@@ -69,23 +39,33 @@ Start the job consumer:
 cuniculus -r my_worker.rb
 ```
 
-### Example
+## Benchmarks
 
-There is also a more complete example in the Cuniculus repository itself. To run it, clone the repository, then
-- start the Ruby and RabbitMQ containers using [Docker Compose](https://docs.docker.com/compose/):
-  ```
-  docker-compose up -d
-  ```
-- from within the _cuniculus_ container, produce a job:
-  ```
-  ruby -Ilib examples/produce.rb
-  ```
-- also from within the container, start the consumer:
-  ```
-  bin/cuniculus -I examples/ -r example/init_cuniculus.rb
-  ```
+The following measurements were performed with the `bin/run_benchmarks` utility, with different command parameters. Run it with `-h` to see its usage.
 
-The `-I examples` option adds the `examples/` directory into the load path, and `-r example/init_cuniculus.rb` requires `init_cuniculus.rb` prior to starting the consumer. The latter is where configurations such as that described in the next section should be.
+To simulate network latency, [Toxiproxy](https://github.com/Shopify/toxiproxy) was used. It needs to be started with `toxiproxy-server` before running the benchmarks.
+
+Network latency (_ms_) | Prefetch count       | Throughput (_jobs/s_) | Average latency (_ms_)
+----------------------:|---------------------:|----------------------:|----------------------:
+1                      | 65535 (max. allowed) | 10225                 | 2
+10                     | 65535 (max. allowed) | 9990                  | 13
+1                      |                   50 | 8051                  | 2
+10                     |                   50 | 2500                  | 13
+100                    |                   50 | 481                   | 103
+1                      |         10 (default) | 5266                  | 2
+10                     |         10 (default) | 807                   | 13
+1                      |                    1 | 481                   | 2
+10                     |                    1 | 81                    | 13
+
+Additional benchmark parameters:
+- throughput was measured by consuming 100k jobs;
+- job latency was averaged over 200 samples;
+- Ruby 2.7.2 was used.
+
+Several remarks can be made:
+- Higher prefetch counts lead to higher throughput, but there are downsides of having it too high; see [this reference](https://www.cloudamqp.com/blog/2017-12-29-part1-rabbitmq-best-practice.html#prefetch) on how to properly tune it.
+- Network latency has a severe impact on the throughput, and the effect is larger the smaller the prefetch count is.
+
 
 ## Configuration
 
@@ -126,6 +106,24 @@ class MyWorker
   end
 end
 ```
+
+## More examples
+
+There is also a more complete example in the Cuniculus repository itself. To run it, clone the repository, then
+- start the Ruby and RabbitMQ containers using [Docker Compose](https://docs.docker.com/compose/):
+  ```
+  docker-compose up -d
+  ```
+- from within the _cuniculus_ container, produce a job:
+  ```
+  ruby -Ilib examples/produce.rb
+  ```
+- also from within the container, start the consumer:
+  ```
+  bin/cuniculus -I examples/ -r example/init_cuniculus.rb
+  ```
+
+The `-I examples` option adds the `examples/` directory into the load path, and `-r example/init_cuniculus.rb` requires `init_cuniculus.rb` prior to starting the consumer. The latter is where configurations such as that described in the next section should be.
 
 ## Error handling
 

--- a/bin/run_benchmarks
+++ b/bin/run_benchmarks
@@ -34,7 +34,7 @@ module CuniculusBenchmarks
   }.freeze
 
   class NoOpWorker
-    include Cuniculus::Worker
+    extend Cuniculus::Worker
     cuniculus_options queue: "benchmark"
 
     def perform(iter, start_time = nil)

--- a/cuniculus.gemspec
+++ b/cuniculus.gemspec
@@ -5,7 +5,7 @@ CUNICULUS_GEMSPEC = Gem::Specification.new do |gem|
   gem.platform = Gem::Platform::RUBY
   gem.extra_rdoc_files = ["README.md", "CHANGELOG.md"]
   gem.rdoc_options += ["--quiet", "--line-numbers", "--inline-source", "--title",
-                       "Cuniculus: Background job processing with RabbitMQ", "--main", "README.rdoc"]
+                       "Cuniculus: Background job processing with RabbitMQ", "--main", "README.md"]
   gem.summary = "Job queue processing backed by RabbitMQ"
   gem.description = gem.summary
   gem.author = "Marcelo Pereira"

--- a/examples/my_worker.rb
+++ b/examples/my_worker.rb
@@ -4,7 +4,7 @@ require "cuniculus/worker"
 
 module Examples
   class MyWorker
-    include Cuniculus::Worker
+    extend Cuniculus::Worker
     cuniculus_options queue: "my_queue"
 
     def perform(arg1)

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -6,7 +6,7 @@ require "cuniculus/worker"
 RSpec.describe Cuniculus::Worker do
   let(:worker) do
     Class.new do
-      include Cuniculus::Worker
+      extend Cuniculus::Worker
     end
   end
   describe "cuniculus_options" do
@@ -15,7 +15,7 @@ RSpec.describe Cuniculus::Worker do
     context "when cuniculus_options is not called" do
       it "uses default values" do
         expect(worker.cun_opts).to include(
-          "queue" => "cun_default"
+          queue: "cun_default"
         )
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Cuniculus::Worker do
 
     context "when invalid keys are passed" do
       let(:opts) do
-        { "invalid_key" => 123, "another_invalid_key" => 3, "queue" => "q" }
+        { invalid_key: 123, "another_invalid_key" => 3, queue: "q" }
       end
       it { expect { subject }.to raise_exception(Cuniculus::WorkerOptionsError) }
     end
@@ -37,19 +37,19 @@ RSpec.describe Cuniculus::Worker do
         Class.new(worker)
       end
       before do
-        worker.cuniculus_options({ "queue" => "q1" })
+        worker.cuniculus_options({ queue: "q1" })
       end
 
       it "inherits the options from the parent worker" do
-        expect(child_worker.cun_opts["queue"]).to eq("q1")
+        expect(child_worker.cun_opts[:queue]).to eq("q1")
       end
 
       context "when child worker overrides the options" do
-        before { child_worker.cuniculus_options({ "queue" => "q2" }) }
-        it { expect(child_worker.cun_opts["queue"]).to eq("q2") }
+        before { child_worker.cuniculus_options({ queue: "q2" }) }
+        it { expect(child_worker.cun_opts[:queue]).to eq("q2") }
 
         it "does not change the parent worker options" do
-          expect(worker.cun_opts["queue"]).to eq("q1")
+          expect(worker.cun_opts[:queue]).to eq("q1")
         end
       end
     end


### PR DESCRIPTION
With this PR, instead of using `include Cuniculus::Worker` to add the async methods, one should now use `extend Cuniculus::Worker`.

As `Worker` is adding methods to the singleton class, not instance methods, this is more appropriate. Further, it simplifies the logic that allows subclasses of a worker to inherit the `cuniculus_options` from its parents.

